### PR TITLE
(fix) - OGISVC-3944- Use the nickname when the value is set 

### DIFF
--- a/oidc-lib/src/main/java/nl/finalist/liferay/oidc/LibFilter.java
+++ b/oidc-lib/src/main/java/nl/finalist/liferay/oidc/LibFilter.java
@@ -176,7 +176,13 @@ public class LibFilter {
             liferay.debug("Response from UserInfo request: " + userInfoResponse.getBody());
             Map openIDUserInfo = new ObjectMapper().readValue(userInfoResponse.getBody(), HashMap.class);
 
-
+           // If legacyUsername is present, we replace the nickname value (used later as username in liferay)
+            String legacyUsername = (String) openIDUserInfo.get("https://extranet.optimumgeneral.com/legacyUsername");
+            liferay.debug("legacyUsername is " +  legacyUsername);
+            if (legacyUsername != null) {
+                openIDUserInfo.put("nickname", legacyUsername);
+            }
+            
             liferay.debug("Setting OpenIDUserInfo object in session: " + openIDUserInfo);
             request.getSession().setAttribute(OPENID_CONNECT_SESSION_ATTR, openIDUserInfo);
 


### PR DESCRIPTION
Use the nickname as alternative attribute when set